### PR TITLE
corrigindo layout da navbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,22 @@
 import './index.css';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import GlobalTerminalHost from './features/terminal/GlobalTerminalHost';
-import AppShell from './features/shared/components/layout/AppShell';
+import AppShell from './features/shared/components/sidebar/AppShell';
 
 export default function App() {
+  const location = useLocation();
+  const isLoginRoute = location.pathname === '/login';
+
   return (
     <div className="min-h-screen">
       <GlobalTerminalHost />
-      <AppShell>
+      {isLoginRoute ? (
         <Outlet />
-      </AppShell>
+      ) : (
+        <AppShell>
+          <Outlet />
+        </AppShell>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/containersImages/ListContainerImages.tsx
+++ b/frontend/src/features/containersImages/ListContainerImages.tsx
@@ -43,7 +43,7 @@ const ListContainersImages: React.FC = () => {
   };
 
   return (
-    <div className="w-full max-w-7xl mx-auto p-4 text-[var(--system-black)] dark:text-[var(--system-white)]">
+    <div className="w-full max-w-7xl mx-auto px-4 py-4 text-[var(--system-black)] dark:text-[var(--system-white)] sm:px-6 lg:px-8">
       <Toolbar
         view={view}
         query={query}
@@ -55,7 +55,7 @@ const ListContainersImages: React.FC = () => {
       />
 
       {view === 'grid' ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {filteredSorted.map((image) => (
             <ImageCard
               key={image.Id ?? Math.random().toString(36)}

--- a/frontend/src/features/containersImages/components/cards/ImageCard.tsx
+++ b/frontend/src/features/containersImages/components/cards/ImageCard.tsx
@@ -55,72 +55,69 @@ const ImageCard: React.FC<ImageProps> = ({ image, onDeleted }) => {
   };
 
   return (
-    <div className="rounded-2xl p-4 transition bg-[var(--system-white)] dark:bg-[var(--dark-primary)] dark:text-[var(--system-white)] border border-[var(--light-gray)] dark:border-[var(--dark-tertiary)] flex justify-between">
-      <div className="flex flex-col flex-1">
-        <div className="flex items-start gap-3">
-          <div className="p-2 rounded-xl bg-[var(--system-white)] dark:bg-[var(--dark-primary)] dark:border-[var(--dark-tertiary)]  border border-[var(--light-gray)]">
+    <div className="flex flex-col gap-4 rounded-2xl border border-[var(--light-gray)] bg-[var(--system-white)] p-4 transition dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-primary)] dark:text-[var(--system-white)]">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="flex items-center justify-center rounded-xl border border-[var(--light-gray)] bg-[var(--system-white)] p-2 dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-primary)]">
             <DockerImageIcon className="text-[var(--docker-blue)]" />
           </div>
 
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-semibold truncate">{name}</span>
-              <span className="text-xs px-2 py-0.5 rounded-full flex items-center gap-1 bg-[var(--system-white)] dark:bg-[var(--dark-primary)] dark:text-[var(--system-white)] border border-[var(--light-gray)] dark:border-[var(--dark-tertiary)]">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="truncate font-semibold">{name}</span>
+              <span className="flex items-center gap-1 rounded-full border border-[var(--light-gray)] bg-[var(--system-white)] px-2 py-0.5 text-xs dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-primary)] dark:text-[var(--system-white)]">
                 <FaTag />
                 {tag}
               </span>
               {!image.RepoTags?.length && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-[var(--system-white)] dark:bg-[var(--dark-primary)] border border-[var(--light-gray)] dark:text-[var(--system-white)] text-[var(--system-black)] dark:border-[var(--dark-tertiary)]">
+                <span className="rounded-full border border-[var(--light-gray)] bg-[var(--system-white)] px-2 py-0.5 text-xs text-[var(--system-black)] dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-primary)] dark:text-[var(--system-white)]">
                   dangling
                 </span>
               )}
             </div>
 
-            <div className="mt-1 text-sm flex flex-wrap gap-x-4 gap-y-1">
+            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm">
               <span title="Tamanho">{FormatBytes(image.Size)}</span>
               <span title="Criado">
                 {EpochToDateStr(image.Created)} <span>({FmtAgo(image.Created)} atrás)</span>
               </span>
-              <span title="Containers que usam">
-                {image.Containers === -1 ? '' : image.Containers}
-              </span>
+              <span title="Containers que usam">{image.Containers === -1 ? '' : image.Containers}</span>
             </div>
           </div>
         </div>
-        <div className="mt-3 flex items-center gap-3">
+
+        <div className="flex flex-col gap-2 sm:w-48 md:w-auto md:flex-row md:items-start md:justify-end">
           <button
             onClick={() => copyToClipboard(id.replace('sha256:', ''), 'ID da imagem copiado')}
-            className="inline-flex hover:scale-95 items-center gap-2 px-3 py-1.5 rounded-xl dark:text-[var(--system-white)] bg-[var(--system-white)] dark:bg-[var(--dark-secondary)] border border-[var(--light-gray)] dark:border-[var(--dark-tertiary)]"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--light-gray)] bg-[var(--system-white)] px-3 py-1.5 text-sm transition hover:scale-95 dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-secondary)] dark:text-[var(--system-white)] md:w-auto"
           >
             <MdContentCopy /> Copiar ID
           </button>
 
           <button
             onClick={() => copyToClipboard(`${name}:${tag}`, 'Nome:tag copiado')}
-            className="inline-flex items-center hover:scale-95 gap-2 px-3 py-1.5 rounded-xl dark:text-[var(--system-white)] bg-[var(--system-white)] dark:bg-[var(--dark-secondary)] border border-[var(--light-gray)] dark:border-[var(--dark-tertiary)]"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--light-gray)] bg-[var(--system-white)] px-3 py-1.5 text-sm transition hover:scale-95 dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-secondary)] dark:text-[var(--system-white)] md:w-auto"
           >
             <MdContentCopy /> Copiar nome:tag
           </button>
         </div>
       </div>
 
-      <div className="flex flex-col justify-between items-end ml-4">
+      <div className="flex items-center justify-end gap-4">
         <button
           onClick={handleDelete}
           title="Excluir"
-          className="cursor-pointer hover:scale-95 text-[var(--exit-red)]"
+          className="flex items-center justify-center text-[var(--exit-red)] transition hover:scale-95"
         >
-          <FaTrashCan className="w-5 h-5" />
+          <FaTrashCan className="h-5 w-5" />
         </button>
 
         <button
-          onClick={() => {
-            handleInspect();
-          }}
+          onClick={handleInspect}
           title="Inspecionar Imagem"
-          className="cursor-pointer hover:scale-95 text-[var(--system-black)] dark:text-[var(--system-white)]"
+          className="flex items-center justify-center text-[var(--system-black)] transition hover:scale-95 dark:text-[var(--system-white)]"
         >
-          <MdContentPasteSearch className="w-6 h-6" />
+          <MdContentPasteSearch className="h-6 w-6" />
         </button>
       </div>
 

--- a/frontend/src/features/shared/components/sidebar/AppShell.tsx
+++ b/frontend/src/features/shared/components/sidebar/AppShell.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { HiOutlineMenuAlt3 } from 'react-icons/hi';
+import Sidebar from './Sidebar';
+import ToggleThemeButton from '../buttons/ToggleThemeButton';
+
+interface AppShellProps {
+  children: React.ReactNode;
+}
+
+const AppShell: React.FC<AppShellProps> = ({ children }) => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+  const desktopPadding = isSidebarCollapsed ? 'lg:pl-24 xl:pl-28' : 'lg:pl-72';
+
+  return (
+    <div className="relative flex min-h-screen bg-[var(--system-white)] text-[var(--system-black)] transition-colors duration-200 dark:bg-[var(--dark-primary)] dark:text-[var(--system-white)]">
+      <Sidebar
+        open={isSidebarOpen}
+        collapsed={isSidebarCollapsed}
+        onClose={() => setIsSidebarOpen(false)}
+        onToggleCollapse={() => setIsSidebarCollapsed((prev) => !prev)}
+      />
+
+      <div className={`flex min-h-screen flex-1 flex-col transition-[padding] duration-200 ${desktopPadding}`}>
+        <header className="flex items-center justify-between border-b border-[var(--light-gray)] bg-[var(--system-white)] px-4 py-3 shadow-sm dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-secondary)] lg:hidden">
+          <button
+            onClick={() => setIsSidebarOpen(true)}
+            className="inline-flex items-center rounded-lg border border-[var(--light-gray)] bg-[var(--system-white)] p-2 text-[var(--medium-gray)] transition hover:bg-[var(--light-overlay)] dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-secondary)] dark:text-[var(--system-white)]"
+            aria-label="Abrir menu"
+          >
+            <HiOutlineMenuAlt3 className="h-6 w-6" />
+          </button>
+          <span className="text-sm font-semibold uppercase tracking-wide text-[var(--medium-gray)] dark:text-[var(--grey-text)]">
+            Docker Manager
+          </span>
+          <ToggleThemeButton />
+        </header>
+
+        <main className="flex flex-1 flex-col px-4 py-6 sm:px-6 lg:px-8 xl:px-10">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/frontend/src/features/shared/components/sidebar/Sidebar.tsx
+++ b/frontend/src/features/shared/components/sidebar/Sidebar.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import {
+  HiOutlineChevronLeft,
+  HiOutlineChevronRight,
+  HiOutlineHome,
+  HiOutlineLogout,
+  HiOutlineServer,
+  HiOutlineX,
+} from 'react-icons/hi';
+import ToggleThemeButton from '../buttons/ToggleThemeButton';
+
+interface SidebarProps {
+  open: boolean;
+  collapsed: boolean;
+  onClose: () => void;
+  onToggleCollapse: () => void;
+}
+
+const navItems = [
+  {
+    label: 'Painel',
+    description: 'Visão geral dos containers',
+    to: '/home',
+    icon: HiOutlineHome,
+  },
+  {
+    label: 'Conexões SSH',
+    description: 'Acesse servidores remotos',
+    to: '/createConnectionForm',
+    icon: HiOutlineServer,
+  },
+  {
+    label: 'Entrar',
+    description: 'Gerencie suas credenciais',
+    to: '/login',
+    icon: HiOutlineLogout,
+  },
+];
+
+const Sidebar: React.FC<SidebarProps> = ({ open, collapsed, onClose, onToggleCollapse }) => {
+  const desktopWidthClass = collapsed ? 'lg:w-24 xl:w-28' : 'lg:w-72';
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        className={`fixed inset-0 z-30 bg-[var(--dark-overlay)] transition-opacity duration-200 lg:hidden ${open ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+      />
+
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 flex w-72 transform flex-col overflow-y-auto bg-[var(--system-white)] px-6 py-8 text-[var(--system-black)] shadow-xl transition-transform duration-200 dark:bg-[var(--dark-secondary)] dark:text-[var(--system-white)] lg:translate-x-0 ${
+          open ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+        } ${collapsed ? 'lg:px-4' : 'lg:px-6'} ${desktopWidthClass}`}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div
+              className={`hidden h-12 w-12 items-center justify-center rounded-2xl border border-[var(--light-gray)] text-lg font-semibold text-[var(--docker-blue)] dark:border-[var(--dark-tertiary)] dark:text-[var(--docker-blue)] lg:flex ${
+                collapsed ? '' : 'lg:hidden'
+              }`}
+            >
+              DM
+            </div>
+            <div className={`${collapsed ? 'lg:hidden' : ''}`}>
+              <span className="text-xs uppercase tracking-[0.3em] text-[var(--medium-gray)] dark:text-[var(--grey-text)]">
+              Docker Manager
+            </span>
+            <h1 className="mt-2 text-2xl font-semibold">Painel</h1>
+          </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[var(--light-gray)] text-[var(--medium-gray)] transition hover:bg-[var(--light-overlay)] dark:border-[var(--dark-tertiary)] dark:text-[var(--system-white)] lg:hidden"
+            aria-label="Fechar menu"
+          >
+            <HiOutlineX className="h-5 w-5" />
+          </button>
+          <button
+            onClick={onToggleCollapse}
+            className="hidden h-9 w-9 items-center justify-center rounded-full border border-[var(--light-gray)] text-[var(--medium-gray)] transition hover:bg-[var(--light-overlay)] dark:border-[var(--dark-tertiary)] dark:text-[var(--system-white)] lg:inline-flex"
+            aria-label={collapsed ? 'Expandir menu' : 'Recolher menu'}
+            title={collapsed ? 'Expandir menu' : 'Recolher menu'}
+          >
+            {collapsed ? <HiOutlineChevronRight className="h-5 w-5" /> : <HiOutlineChevronLeft className="h-5 w-5" />}
+          </button>
+        </div>
+
+        <nav
+          className={`mt-10 flex flex-1 flex-col gap-2 ${collapsed ? 'lg:items-center lg:gap-3' : ''}`}
+          aria-label="Menu principal"
+        >
+          {navItems.map(({ label, description, to, icon: Icon }) => (
+            <NavLink
+              key={to}
+              to={to}
+              onClick={onClose}
+              title={label}
+              className={({ isActive }) =>
+                `group flex items-center gap-3 rounded-xl border border-transparent bg-transparent px-4 py-3 transition hover:border-[var(--light-gray)] hover:bg-[var(--light-overlay)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--docker-blue)] dark:hover:border-[var(--dark-tertiary)] dark:hover:bg-[var(--dark-tertiary)] ${
+                  collapsed ? 'lg:w-full lg:justify-center lg:px-2' : ''
+                } ${
+                  isActive
+                    ? 'border-[var(--docker-blue)] bg-[var(--light-overlay)] text-[var(--docker-blue)] dark:border-[var(--docker-blue)] dark:bg-[var(--dark-tertiary)]'
+                    : 'text-[var(--medium-gray)] dark:text-[var(--grey-text)]'
+                }`
+              }
+            >
+              <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--light-gray)] text-lg transition group-hover:border-[var(--docker-blue)] group-hover:text-[var(--docker-blue)] dark:border-[var(--dark-tertiary)]">
+                <Icon className="h-5 w-5" />
+              </span>
+              <div className={`flex flex-col ${collapsed ? 'lg:hidden' : ''}`}>
+                <span className="font-semibold text-current">{label}</span>
+                <span className="text-xs text-[var(--medium-gray)] dark:text-[var(--grey-text)]">{description}</span>
+              </div>
+            </NavLink>
+          ))}
+        </nav>
+
+        <div
+          className={`mt-6 rounded-xl border border-[var(--light-gray)] bg-[var(--light-overlay)] dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-tertiary)] ${
+            collapsed ? 'lg:flex lg:flex-col lg:items-center lg:gap-2 lg:p-3' : 'p-4'
+          }`}
+        >
+          <h2
+            className={`text-sm font-semibold text-[var(--system-black)] dark:text-[var(--system-white)] ${
+              collapsed ? 'lg:hidden' : ''
+            }`}
+          >
+            Tema
+          </h2>
+          <p
+            className={`mt-1 text-xs text-[var(--medium-gray)] dark:text-[var(--grey-text)] ${
+              collapsed ? 'lg:hidden' : ''
+            }`}
+          >
+            Alterne entre os modos claro e escuro para personalizar sua experiência.
+          </p>
+          <div className={`mt-3 ${collapsed ? 'lg:mt-0' : ''}`}>
+            <ToggleThemeButton />
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import LoginForm from '../features/login/LoginForm';
 
 const LoginPage: React.FC = () => {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center">
+    <div className="flex min-h-screen flex-col items-center justify-center px-4 py-10">
       <div className="w-full max-w-md rounded-2xl border border-[var(--light-gray)] bg-[var(--system-white)] p-8 shadow-lg dark:border-[var(--dark-tertiary)] dark:bg-[var(--dark-secondary)]">
         <div className="mb-6 text-center">
           <h1 className="text-2xl font-semibold text-[var(--system-black)] dark:text-[var(--system-white)]">Acesse sua conta</h1>


### PR DESCRIPTION
## Summary
- rename the shared sidebar module and add a collapsible desktop experience
- remove the shell from the login route and center the login form independently
- tighten the container images grid and card layouts for better responsiveness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f933c462e883268fc41d184d061754